### PR TITLE
Remove warning that this is in beta in the read me

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,6 @@ The ``neotime`` module defines classes for working with temporal data to nanosec
 These classes comprise a similar set to that provided by the standard library ``datetime`` module.
 Inspiration has also been drawn from `ISO-8601 <https://xkcd.com/1179/>`_.
 
-.. note:: Neotime is currently beta quality software.
-
 
 Overview
 ========


### PR DESCRIPTION
Since v1.0.0 is released and the latest Python Neo4j driver requires this dependency, I can assume this is no longer beta quality code.