### PR TITLE
Include LICENSE.txt in the PyPi release tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 global-exclude *.class *.pyc *.pyo *.so *.dll __pycache__
 prune test
+include LICENSE.txt


### PR DESCRIPTION
This will help various Linux distribution packagers package this Python module. I'm going through this process in Fedora and EPEL since this is now a dependency in Python Neo4j driver 1.6.