### PR TITLE
Fixes Problems with install & pytz - when pytz wasn't installed before...

### DIFF
--- a/neotime/__init__.py
+++ b/neotime/__init__.py
@@ -30,9 +30,9 @@ from time import gmtime, mktime, struct_time
 ##Just ensures that module can be imported on install, becuase offset is not needed when importing while install.
 ##After the install it should work every time, cause pytz is installed with the packge.
 try:
-    from pytz import offset
+    from pytz import FixedOffset
 except:
-    def offset():
+    def FixedOffset():
         raise Exception("I seems like pytz is not installed or there is an error with your pytz installation. Please reinstall pytz.")
 
 

--- a/neotime/__init__.py
+++ b/neotime/__init__.py
@@ -33,7 +33,7 @@ try:
     from pytz import offset
 except:
     def offset():
-        pass
+        raise Exception("I seems like pytz is not installed or there is an error with your pytz installation. Please reinstall pytz.")
 
 
 try:

--- a/neotime/__init__.py
+++ b/neotime/__init__.py
@@ -27,7 +27,13 @@ from functools import total_ordering
 from re import compile as re_compile
 from time import gmtime, mktime, struct_time
 
-from pytz import FixedOffset
+##Just ensures that module can be imported on install, becuase offset is not needed when importing while install.
+##After the install it should work every time, cause pytz is installed with the packge.
+try:
+    from pytz import offset
+except:
+    def offset():
+        pass
 
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ except ImportError:
 from neotime.meta import package, version
 
 
+
 install_requires = [
     "pytz",
     "six",


### PR DESCRIPTION
Fixes issue #4. The problem was that the method `offset` in `__init__.py` in called while install, because the module `neotime.meta`  ist imported. But before the install pytz isn't available. There were two possible fixes to that. First one was changing package structure, but i didn't wanted to do this, because this could cause breaks in other packages that depends on neotime. 

So I choosed the second solution, which was replacing the function when pytz isn't available, that should only happen while installation time. I added also an exception just in case there are errors with pytz outside of the installation time (e.g. uninstalled later by accident ...).

Hope you like my suggestion how to fix this.

Test are all passing as well:


> neotime(1.7*)$ py.test ./test
> ============================================================================ test session starts =============================================================================
> platform darwin -- Python 3.6.6, pytest-4.0.1, py-1.7.0, pluggy-0.8.0
> rootdir: /Users/lbiermann/Documents/neotime, inifile:
> collected 225 items                                                                                                                                                          
> 
> test/test_clock.py .....                                                                                                                                               [  2%]
> test/test_clocktime.py ................                                                                                                                                [  9%]
> test/test_date.py ...........................................................................................                                                          [ 49%]
> test/test_datetime.py ...........................................                                                                                                      [ 68%]
> test/test_duration.py ................................................                                                                                                 [ 90%]
> test/test_time.py ......................                                                                                                                               [100%]
> 
> ============================================================================== warnings summary ==============================================================================
> test/test_date.py::DateTestCase::test_replace
>   /Users/lbiermann/Documents/neotime/test/test_date.py:236: DeprecationWarning: Please use assertEqual instead.
>     self.assertEquals(d2, Date(2017, 4, 30))
> 
> -- Docs: https://docs.pytest.org/en/latest/warnings.html
